### PR TITLE
Updated to work with terminaltables 3.1.0 where UnixTables is moved t…

### DIFF
--- a/src/cache_simulator.py
+++ b/src/cache_simulator.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 import yaml, cache, argparse, logging, pprint
-from terminaltables import UnixTable
+from terminaltables.other_tables import UnixTable
 
 def main():
     #Set up our arguments


### PR DESCRIPTION
Starting with this commit: https://github.com/Robpol86/terminaltables/commit/091f1019a6170ff5b842f385892ef6333977d8da 
terminaltables moved the UnixTable in other_tables.

I changed the import to correctly reflect the way terminaltables is in version 3.1.0